### PR TITLE
refactor(#15): 변경된 화면명세서에 따른 레이아웃 변경

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,26 @@
 import { Routes, Route } from "react-router-dom";
-import Home from "@/pages/Home";
 import PublicRoute from "@routes/PublicRoute";
 import NotFound from "@pages/404";
+import Layout from "@components/Layout";
+import { useAuthStore } from "@/store/auth";
 
 function App() {
+  const { role } = useAuthStore();
+
+  // if (role === "NOT_LOGGED_IN") {
+  //   return <Login />;
+  // }
+
   return (
-    <>
-      <Routes>
-        <Route
-          path="/"
-          element={
-            <PublicRoute>
-              <Home />
-            </PublicRoute>
-          }
-        />
+    <Routes>
+      <Route element={<Layout />}>
+        <Route path="/">
+          {/* 
+          role 별로 페이지를 구현해야함.
+          Home을 만들고 그 안에 구현할지, 
+          role 별로 페이지를 만들어서 라우팅할지 아직 미정
+        */}
+        </Route>
         <Route
           path="*"
           element={
@@ -23,8 +29,8 @@ function App() {
             </PublicRoute>
           }
         />
-      </Routes>
-    </>
+      </Route>
+    </Routes>
   );
 }
 

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -1,22 +1,22 @@
-import { ReactNode } from "react";
 import "@coreui/coreui/dist/css/coreui.min.css";
+import { CContainer } from "@coreui/react";
 import Header from "@components/Header";
 import Sidebar from "@components/Sidebar";
-import { CContainer } from "@coreui/react";
+import MiniHeader from "@components/MiniHeader";
+import { Outlet } from "react-router-dom";
 
-type LayoutProps = {
-  children: ReactNode;
-};
-
-const Layout = ({ children }: LayoutProps) => {
+const Layout = () => {
   return (
     <div className="c-app">
       <div className="c-wrapper d-flex">
         <Sidebar />
         <div className="c-body flex-grow-1">
           <Header />
+          <MiniHeader />
           <main className="c-main">
-            <CContainer fluid>{children}</CContainer>
+            <CContainer fluid>
+              <Outlet />
+            </CContainer>
           </main>
         </div>
       </div>

--- a/src/components/MiniHeader/index.tsx
+++ b/src/components/MiniHeader/index.tsx
@@ -1,0 +1,14 @@
+import { CHeader } from "@coreui/react";
+
+const MiniHeader = () => {
+  return (
+    <CHeader
+      className="border-bottom"
+      style={{ height: "48px", backgroundColor: "#f8f9fa" }}
+    >
+      Home
+    </CHeader>
+  );
+};
+
+export default MiniHeader;

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -6,16 +6,18 @@ import {
   CSidebarNav,
   CNavTitle,
   CNavItem,
-  CNavGroup,
   CSidebarToggler,
 } from "@coreui/react";
-import { CIcon } from "@coreui/icons-react";
 import { NavItem } from "@/types/sidebar";
 import { navigationConfig } from "@/config/navigation";
 import SidebarItem from "@components/SidebarItem";
 import { useNavigate } from "react-router-dom";
+import { useAuthStore } from "@/store/auth";
+import CIcon from "@coreui/icons-react";
+import { cilPencil } from "@coreui/icons";
 
-const Sidebar: React.FC = () => {
+const Sidebar = () => {
+  const { role } = useAuthStore();
   let navigate = useNavigate();
   const onClickSidebarBrand = () => {
     navigate("/");
@@ -24,29 +26,27 @@ const Sidebar: React.FC = () => {
     return items.map((item, index) => {
       if (item.items) {
         return (
-          <CNavGroup
-            key={index}
-            toggler={
-              <>
-                <CIcon customClassName="nav-icon" icon={item.icon} />{" "}
-                {item.name}
-              </>
-            }
-          >
+          <React.Fragment key={index}>
+            <CNavTitle>{item.name}</CNavTitle>
             {item.items.map((subItem, subIndex) => (
               <CNavItem key={subIndex} href={subItem.href}>
                 <span className="nav-icon">
-                  <span className="nav-icon-bullet"></span>
+                  <span className="nav-icon">
+                    <CIcon icon={cilPencil} />
+                  </span>
                 </span>{" "}
                 {subItem.name}
               </CNavItem>
             ))}
-          </CNavGroup>
+          </React.Fragment>
         );
       }
       return <SidebarItem key={index} {...item} />;
     });
   };
+
+  // 아래 코드는 추후 백엔드까지 구현되면 삭제 후 role만 사용.
+  const sidebarRole = role && navigationConfig[role] ? role : "STUDENT";
 
   return (
     <CSidebar className="border-end" style={{ height: "100vh" }}>
@@ -68,12 +68,7 @@ const Sidebar: React.FC = () => {
         </CSidebarBrand>
       </CSidebarHeader>
       <CSidebarNav style={{ backgroundColor: "#f8f9fa" }}>
-        {Object.entries(navigationConfig).map(([title, items]) => (
-          <React.Fragment key={title}>
-            <CNavTitle>{title}</CNavTitle>
-            {renderNavItems(items)}
-          </React.Fragment>
-        ))}
+        {renderNavItems(navigationConfig[sidebarRole])}
       </CSidebarNav>
       <CSidebarHeader className="border-top">
         <CSidebarToggler />

--- a/src/components/SidebarItem/index.tsx
+++ b/src/components/SidebarItem/index.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { CNavItem } from "@coreui/react";
 import { CIcon } from "@coreui/icons-react";
 
@@ -8,7 +7,7 @@ interface NavItemProps {
   href?: string;
 }
 
-const SidebarItem: React.FC<NavItemProps> = ({ name, icon, href }) => (
+const SidebarItem = ({ name, icon, href }: NavItemProps) => (
   <CNavItem href={href}>
     {icon && <CIcon customClassName="nav-icon" icon={icon} />} {name}
   </CNavItem>

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -1,29 +1,11 @@
-import { cilUser, cilBuilding, cilPuzzle } from "@coreui/icons";
+import { cilPencil } from "@coreui/icons";
 import { NavItem } from "../types/sidebar";
 
 // href는 추후 Link 사용시 변경
 export const navigationConfig: Record<string, NavItem[]> = {
-  공통: [
-    {
-      name: "학생관리",
-      icon: cilUser,
-      href: "#",
-    },
-    {
-      name: "학과관리",
-      icon: cilBuilding,
-      href: "#",
-    },
-    {
-      name: "교수관리",
-      icon: cilUser,
-      href: "#",
-    },
-  ],
-  아이템: [
+  STUDENT: [
     {
       name: "인턴십",
-      icon: cilPuzzle,
       items: [
         { name: "신청", href: "#" },
         { name: "결과 입력", href: "#" },
@@ -31,7 +13,6 @@ export const navigationConfig: Record<string, NavItem[]> = {
     },
     {
       name: "장학금",
-      icon: cilPuzzle,
       items: [
         { name: "SW Expert", href: "#" },
         { name: "SW 서포터즈", href: "#" },
@@ -43,10 +24,100 @@ export const navigationConfig: Record<string, NavItem[]> = {
     },
     {
       name: "SW 역량테스트",
-      icon: cilPuzzle,
       items: [
         { name: "신청", href: "#" },
         { name: "결과 입력", href: "#" },
+      ],
+    },
+  ],
+  PROFESSOR: [
+    {
+      name: "분석",
+      items: [
+        { name: "Solid Cloud", href: "#" },
+        { name: "인턴쉽", href: "#" },
+        { name: "경진대회", href: "#" },
+        { name: "장학금", href: "#" },
+        { name: "SW 역량 테스트", href: "#" },
+        { name: "SW 정원 비율", href: "#" },
+        { name: "교원 1인당 학생수", href: "#" },
+        { name: "산학협력 프로젝트 참여률", href: "#" },
+        { name: "SW 전공생 취업률", href: "#" },
+      ],
+    },
+    {
+      name: "지표",
+      icon: cilPencil,
+      items: [
+        { name: "주요 성과 지표", href: "#" },
+        { name: "자율 성과 지표", href: "#" },
+      ],
+    },
+  ],
+  SUPER_ADMIN: [
+    {
+      name: "분석",
+      items: [
+        { name: "Solid Cloud 활용", href: "#" },
+        { name: "인턴쉽", href: "#" },
+        { name: "경진대회", href: "#" },
+        { name: "장학금", href: "#" },
+        { name: "SW 역량 테스트", href: "#" },
+        { name: "SW 정원 비율", href: "#" },
+        { name: "교원 1인당 학생수", href: "#" },
+        { name: "산학협력 프로젝트 참여률", href: "#" },
+        { name: "SW 전공생 취엽률", href: "#" },
+      ],
+    },
+    {
+      name: "관리",
+      icon: cilPencil,
+      items: [
+        { name: "학생 관리", href: "#" },
+        { name: "교수 관리", href: "#" },
+        { name: "관리자 관리", href: "#" },
+        { name: "아이템 관리", href: "#" },
+        { name: "양식함 관리", href: "#" },
+      ],
+    },
+    {
+      name: "지표",
+      items: [
+        { name: "주요 성과 지표", href: "#" },
+        { name: "자율 성과 지표", href: "#" },
+      ],
+    },
+  ],
+  ADMIN: [
+    {
+      name: "분석",
+      items: [
+        { name: "Solid Cloud 활용", href: "#" },
+        { name: "인턴쉽", href: "#" },
+        { name: "경진대회", href: "#" },
+        { name: "장학금", href: "#" },
+        { name: "SW 역량 테스트", href: "#" },
+        { name: "SW 정원 비율", href: "#" },
+        { name: "교원 1인당 학생수", href: "#" },
+        { name: "산학협력 프로젝트 참여률", href: "#" },
+        { name: "SW 전공생 취엽률", href: "#" },
+      ],
+    },
+    {
+      name: "관리",
+      icon: cilPencil,
+      items: [
+        { name: "학생 관리", href: "#" },
+        { name: "교수 관리", href: "#" },
+        { name: "아이템 관리", href: "#" },
+        { name: "양식함 관리", href: "#" },
+      ],
+    },
+    {
+      name: "지표",
+      items: [
+        { name: "주요 성과 지표", href: "#" },
+        { name: "자율 성과 지표", href: "#" },
       ],
     },
   ],

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -16,7 +16,7 @@ export const navigationConfig: Record<string, NavItem[]> = {
       items: [
         { name: "SW Expert", href: "#" },
         { name: "SW 서포터즈", href: "#" },
-        { name: "SKU StartTrack", href: "#" },
+        { name: "SKU StarTrack", href: "#" },
         { name: "SW 인재", href: "#" },
         { name: "SW 유망주", href: "#" },
         { name: "SW 융합", href: "#" },

--- a/src/pages/404/index.tsx
+++ b/src/pages/404/index.tsx
@@ -1,17 +1,14 @@
-import Layout from "@/components/Layout";
 import GoBackHomeButton from "@components/Button/GoBackHomeButton.tsx";
 import styles from "./NotFound.module.css";
 
 const NotFound = () => {
-    return (
-        <Layout>
-            <div className={styles.container}>
-                <h1 className={styles.heading}>존재하지 않는 페이지입니다.</h1>
-                <small className={styles.errorCode}>404 NOT FOUND</small>
-                <GoBackHomeButton />
-            </div>
-        </Layout>
-    );
+  return (
+    <div className={styles.container}>
+      <h1 className={styles.heading}>존재하지 않는 페이지입니다.</h1>
+      <small className={styles.errorCode}>404 NOT FOUND</small>
+      <GoBackHomeButton />
+    </div>
+  );
 };
 
 export default NotFound;

--- a/src/pages/500/index.tsx
+++ b/src/pages/500/index.tsx
@@ -1,18 +1,15 @@
-import Layout from "@/components/Layout";
 import GoBackHomeButton from "@components/Button/GoBackHomeButton.tsx";
 import styles from "./InternalError.module.css";
 
 const InternalError = () => {
-    return (
-        <Layout>
-            <div className={styles.container}>
-                <h1 className={styles.heading}>서버에러가 발생했습니다.</h1>
-                <small className={styles.errorCode}>500 Internal Server Error</small>
-                <h3 className={styles.message}>잠시 후 다시 시도해주세요</h3>
-                <GoBackHomeButton />
-            </div>
-        </Layout>
-    );
+  return (
+    <div className={styles.container}>
+      <h1 className={styles.heading}>서버에러가 발생했습니다.</h1>
+      <small className={styles.errorCode}>500 Internal Server Error</small>
+      <h3 className={styles.message}>잠시 후 다시 시도해주세요</h3>
+      <GoBackHomeButton />
+    </div>
+  );
 };
 
 export default InternalError;

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,7 +1,0 @@
-import Layout from "@/components/Layout";
-
-const Home = () => {
-  return <Layout>Home</Layout>;
-};
-
-export default Home;

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -1,18 +1,25 @@
+import { Role } from "@/types/role";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
 interface AuthState {
+  name: string;
+  role: Role;
   isLoggedIn: boolean;
   login: () => void;
   logout: () => void;
+  reset: () => void;
 }
 
 const useAuthStore = create<AuthState>()(
   persist(
     (set) => ({
       isLoggedIn: false,
+      name: "",
+      role: "NOT_LOGGED_IN",
       login: () => set({ isLoggedIn: true }),
-      logout: () => set({ isLoggedIn: false }),
+      logout: () => set({ isLoggedIn: false, name: "", role: "NOT_LOGGED_IN" }),
+      reset: () => set({ isLoggedIn: false, name: "", role: "NOT_LOGGED_IN" }),
     }),
     {
       name: "auth-storage",

--- a/src/types/role.ts
+++ b/src/types/role.ts
@@ -1,0 +1,6 @@
+export type Role =
+  | "STUDENT"
+  | "PROFESSOR"
+  | "ADMIN"
+  | "SUPER_ADMIN"
+  | "NOT_LOGGED_IN";


### PR DESCRIPTION
## 📌 Related Issue

> [!NOTE]
> 관련된 이슈 번호를 적어주세요.

- Close #15 

## 🚀 Description

> [!NOTE]
> 작업한 내용을 간략히 적어주세요.

```text
- 유저 역할에 따라 사이드바 내용 변경
- 기본 레이아웃 수정
- 중복 코드 제거
```

## 📸 Screenshot
> [!NOTE]
> 변경 사항을 보여주는 스크린샷(또는 GIF)을 첨부해 주세요.

<img width="1439" alt="스크린샷 2024-12-20 00 01 57" src="https://github.com/user-attachments/assets/c214691f-5ab3-48c0-8f49-95a9f1df98a9" />

<img width="1435" alt="스크린샷 2024-12-20 00 02 29" src="https://github.com/user-attachments/assets/4b9f000e-1532-4685-821f-f841a3838fc9" />

<img width="721" alt="스크린샷 2024-12-20 00 02 44" src="https://github.com/user-attachments/assets/2df04fa0-22bd-4b7a-892f-2051ed062b0f" />

<img width="1436" alt="스크린샷 2024-12-20 00 03 02" src="https://github.com/user-attachments/assets/23ea7329-aa22-4dfd-a9cd-1f3224817903" />


## 📢 Notes

> [!NOTE]
> 추가적인 설명이나 참고 사항을 작성해 주세요.

```text
화면 명세서엔 헤더에 이름이 있는데, 굳이 필요 없다 생각이 들어 안넣었습니다.

```

